### PR TITLE
bug_fix

### DIFF
--- a/tianji/agents/metagpt_agents/sceneRefinement/role.py
+++ b/tianji/agents/metagpt_agents/sceneRefinement/role.py
@@ -56,6 +56,7 @@ class SceneRefine(Role):
             self.rc.todo = None
 
     async def _react(self) -> Message:
+        msg=None
         while True:
             await self._think()
             if self.rc.todo is None:


### PR DESCRIPTION
tianji/agents/metagpt_agents/sceneRefinement/role.py里的_react函数需要在while循环外给msg赋空值，防止循环break后出现错误UnboundLocalError: local variable 'msg' referenced before assignment
